### PR TITLE
Fix: update mobile dark mode label to show Light Mode in dark theme

### DIFF
--- a/app.js
+++ b/app.js
@@ -49,15 +49,20 @@ const initTheme = () => {
 const updateThemeIcons = (theme) => {
     themeToggles.forEach(toggle => {
         const icon = toggle.querySelector('i');
+        const label = toggle.querySelector('span'); // Get span if exists
+
         if (theme === 'dark') {
             icon.className = 'fa-solid fa-sun';
             toggle.classList.add('dark');
+            if (label) label.textContent = 'Light Mode'; // <-- change label
         } else {
             icon.className = 'fa-solid fa-moon';
             toggle.classList.remove('dark');
+            if (label) label.textContent = 'Dark Mode'; // <-- reset label
         }
     });
 };
+
 
 const toggleTheme = () => {
     const currentTheme = document.documentElement.getAttribute('data-theme');


### PR DESCRIPTION
Updated the theme toggle logic to display **“Light Mode”** beside the sun icon when dark mode is active.  
Previously, it always showed **“Dark Mode”** even in dark theme.

### Before
Shows “Dark Mode” text even when in dark mode.  
<img width="317" height="601" alt="image" src="https://github.com/user-attachments/assets/0ac26905-6041-4225-be9e-e6c5019f29b9" />



---

### After
Shows “Light Mode” text when in dark mode, and “Dark Mode” text when in light mode.  
<img width="317" height="601" alt="a-11" src="https://github.com/user-attachments/assets/820dc5d3-16c1-4439-b216-4955c2f7e2da" />

If possible, please add the `hacktoberfest` label to this PR. Thanks!

