### PR TITLE
fix: prevent section content from being hidden behind fixed navbar

### DIFF
--- a/style.css
+++ b/style.css
@@ -73,7 +73,7 @@ body {
     background-color: var(--eye-ball);
     color: var(--lead);
     transition: background-color 0.4s ease, color 0.4s ease;
-    padding-top: 14vh;
+    padding-top: 15vh; /* to accommodate fixed navbar height */
     /* Added to prevent content from hiding behind the fixed navbar */
 }
 
@@ -111,6 +111,7 @@ body.dark-mode {
 
 html {
     scroll-behavior: smooth;
+    scroll-padding-top: 15vh; /* to accommodate fixed navbar height */
 }
 
 body::-webkit-scrollbar {


### PR DESCRIPTION
This pull request fixes an issue where clicking on navbar links caused the target section to be slightly hidden behind the fixed navigation bar.

The navbar itself was already remaining visible when scrolling, but anchor navigation needed an offset to account for the fixed header’s height.