### PR TITLE
Bug fix in cropped images in popup

### DIFF
--- a/style.css
+++ b/style.css
@@ -832,12 +832,16 @@ input[type="email"]:focus {
 }
 
 .modal-content img {
-    width: 300px;
-    height: 200px;
-    object-fit: cover;
+    width: 100%;
+    max-width: 300px;     /* keep it from getting too big */
+    height: auto;         /* keep correct aspect ratio */
+    object-fit: contain;  /* shows the entire image */
+    display: block;
+    margin: 0 auto;
     position: relative;
-    top: 30px;
+    top: 20px;            /* adjust spacing so buttons don’t overlap */
 }
+
 
 div#card-content-container {
     position: relative;


### PR DESCRIPTION
Updated .modal-content img styles:

Replaced object-fit: cover with object-fit: contain so full food plates are visible.

Set width: 100% with max-width: 300px and height: auto to preserve aspect ratio.

Centered the image with display: block; margin: 0 auto;.

This ensures food item images (e.g., Chocolate Lava Cake) are no longer cropped or overlapped inside the modal.

Improves visual clarity and prevents the "View Cart" button from being hidden.