### PR TITLE
Remove duplicate food modal from index.html

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -457,32 +457,7 @@
             </div>
         </div>
     </div>
-        <div id="foodModal" class="modal">
-            <div class="modal-content">
-                <span class="close back-to-top visible"><i class="fa-solid fa-arrow-left"></i></span>
-                <img id="modalImage" alt="Food image in detail view" />
-
-                <div id="card-content-container">
-                    <h2 id="modalName"></h2>
-                    <p id="modalPrice"></p>
-                    <p id="modalDescription"></p>
-                </div>
-
-                <div id="card-btn-container">
-                    <button id="addToCartBtn">Add to Cart</button>
-                    <button id="viewCartBtn">View Cart</button>
-                </div>
-            </div>
-        </div>
-    </div>
-    
-    <!-- swiper js -->
-    <script src="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.js"></script>
-
-    <!-- app js -->
-    <script src="../JS/app.js"></script>
-    <script src="../JS/cursor.js"></script>
-
+     
     <!-- swiper js -->
     <script src="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.js"></script>
 


### PR DESCRIPTION
This PR is related to Issue #116 that is removing duplicate foodModal block from the index.html file. The same modal structure was present twice, with same id="foodModal" and identical child elements (modalImage, modalName, modalPrice, etc.).

### Problem Can Be Caused By It:
-----------------------------------

- The duplicated IDs violate HTML standard as we know that IDs must be unique.
- JavaScript that is targeting the ID #foodModal and its children may behave unpredictably.
- The Styling and event listeners may apply inconsistently.

### Fixing the Issue By
----------------

- Removing the second instance of the foodModal block.
- Ensured only one modal exists with unique IDs 


<img width="700" height="700" alt="image" src="https://github.com/user-attachments/assets/7242aad7-ce93-4d73-9917-f3f7b31530dc" />

