### PR TITLE
added new feature:chrome extension for deployed site

### DIFF
--- a/chrome extension/manifest.json
+++ b/chrome extension/manifest.json
@@ -1,0 +1,11 @@
+{
+  "manifest_version": 3,
+  "name": "🍽️ Foodie - Responsive Food Delivery App",
+  "version": "1.0.0",
+  "description": "Quick access to Foodie — a fully responsive food delivery platform built with HTML, CSS, and JS. Browse menus, customize orders, and track deliveries instantly.",
+  "permissions": ["tabs"],
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "Open Foodie"
+  }
+}

--- a/chrome extension/popup.css
+++ b/chrome extension/popup.css
@@ -1,0 +1,49 @@
+body {
+  font-family: "Segoe UI", Arial, sans-serif;
+  width: 260px;
+  padding: 15px;
+  background: #f9fafb;
+  text-align: center;
+  transition: background 0.3s;
+}
+
+body:hover {
+  background: #f1f3f9; /* subtle hover effect on popup */
+}
+
+h2 {
+  font-size: 18px;
+  margin-bottom: 8px;
+  color: #1a237e;
+}
+
+p {
+  font-size: 13px;
+  margin: 8px 0;
+  color: #444;
+}
+
+button {
+  width: 100%;
+  padding: 10px;
+  background: #3949ab;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: bold;
+  margin-top: 10px;
+  transition: background 0.2s, transform 0.1s;
+}
+
+button:hover {
+  background: #283593;
+  transform: scale(1.02); /* subtle hover scale effect */
+}
+
+.hint {
+  font-size: 11px;
+  color: #777;
+  margin-top: 6px;
+}

--- a/chrome extension/popup.html
+++ b/chrome extension/popup.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>🍽️ Foodie</title>
+  <link rel="stylesheet" href="popup.css" />
+</head>
+<body>
+  <div id="container">
+    <h2>🍴 Foodie</h2>
+    <p>Fully Responsive Food Delivery App — browse menus, customize orders, and track deliveries in real-time.</p>
+
+    <button id="openApp">🚀 Open Foodie</button>
+    <p class="hint">Quick access to your food delivery dashboard</p>
+  </div>
+
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/chrome extension/popup.js
+++ b/chrome extension/popup.js
@@ -1,0 +1,4 @@
+document.getElementById("openApp").addEventListener("click", () => {
+  chrome.tabs.create({ url: "https://hacktoberfest2025-foodie-rho.vercel.app/" });
+  
+});


### PR DESCRIPTION
Description
This PR implements the feature requested in #118 
. It adds a lightweight Chrome Extension that provides one-click access to the deployed Component Library site.

Changes made:

Added manifest.json for the Chrome Extension.

Added popup.html with a button to open the deployed site.

Added popup.js to handle button click and open the site in a new tab.

Added popup.css for styling the popup.

How to test:

Clone the repo and navigate to the extension folder.

Open Chrome → Extensions → Enable Developer Mode → Load Unpacked → Select the extension folder.

Click the extension icon → popup appears → click “Open FOODIE” → the deployed site opens in a new tab.



<img width="2235" height="1278" alt="image" src="https://github.com/user-attachments/assets/67611f7f-9adb-4a13-8088-89d16cc54178" />

⚠️ Note:  I have used the deployed site link mentioned in the README.
This Pr is a part of hacktoberfest 2025 .kindly label it if valid and review my pr.