### PR TITLE
Fixed: text not displayed properly in add to cart page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -475,7 +475,7 @@ h4 {
 }
 
 .cart-tab-active {
-    inset: 0 0 0 auto;
+    inset: 8rem 0 0 auto;
 }
 
 .cart-list {


### PR DESCRIPTION
Fixed  text not displayed properly in add to cart page
<img width="1002" height="866" alt="cart_fixed" src="https://github.com/user-attachments/assets/d8d04797-7446-44ab-8225-f9ffe7d11b39" />
