### PR TITLE
Feature/back to top icon not visible

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -376,7 +376,7 @@
 
     <a href="#home" class="back-to-top" aria-label="Back to top">
         <i class="fa-solid fa-arrow-up"></i>
-    </a>    
+    </a>
      
     <!-- swiper js -->
     <script src="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.js"></script>


### PR DESCRIPTION
@janavipandole - back to top icon visible issue is fixed.
<img width="1822" height="809" alt="image" src="https://github.com/user-attachments/assets/9c0fa57a-f46e-46af-9855-82746cc59c82" />
