### PR TITLE
fix: browse menu button now redirects to menu page

### DIFF
--- a/html/aboutUs.html
+++ b/html/aboutUs.html
@@ -240,7 +240,7 @@
             <p>Join thousands of satisfied customers and enjoy delicious food delivered to your doorstep</p>
             <div class="cta-buttons">
                 <a href="../HTML/signup.html" class="cta-btn primary">Sign Up Now</a>
-                <a href="../HTML/index.html#menu" class="cta-btn secondary">Browse Menu</a>
+                <a href="../html/menu.html" class="cta-btn secondary">Browse Menu</a>
             </div>
         </div>
     </section>


### PR DESCRIPTION
The Browse Menu button in the about us page is currently functioning as expected. When clicked, it redirects the user to the Menu page.

https://github.com/user-attachments/assets/e8337fdb-b459-4b03-a68f-7c00addc865e


<hr>

### Steps to Reproduce:

- Open the website.
- Locate the Browse Menu button on about us page.

<img width="1000" height="924" alt="Image" src="https://github.com/user-attachments/assets/43fff8f3-b876-45ff-8363-df893bb1cf3d" />

- Click the button Browse Menu.
- Observe that the page now redirects to the Menu page.

@janavipandole can you please review it and assign under hacktober fest
