### PR TITLE
Fix: form switch functionality for login/signup

### DIFF
--- a/js/auth.js
+++ b/js/auth.js
@@ -5,3 +5,19 @@ function togglePassword(inputId) {
 }
 // Make togglePassword globally accessible for inline event handlers
 window.togglePassword = togglePassword;
+
+// implementation of Toggle between login and signup forms
+function switchForm(formType) {
+  const loginForm = document.getElementById("loginForm");
+  const signupForm = document.getElementById("signupForm");
+
+  if (formType === "login") {
+    loginForm.classList.add("active");
+    signupForm.classList.remove("active");
+  } else if (formType === "signup") {
+    signupForm.classList.add("active");
+    loginForm.classList.remove("active");
+  }
+}
+
+window.switchForm = switchForm;


### PR DESCRIPTION
This PR fixes the issue where **login** and **signup forms** were not switching correctly. 


https://github.com/user-attachments/assets/151b9f71-dddf-4e87-b816-50293a7fefb8

<hr>

For this i had implemented a  switchForm( ) function in auth.js now the login and signup forms are switching correctly. 


https://github.com/user-attachments/assets/b4ba8e6d-a648-4946-a32a-e68b8d2e65f0


### Changes
- I had added switchForm( ) function to toggle between the **login** and **signup forms**
- Also I had made it globally accessible via window.switchForm

<hr>

@janavipandole can you please assign me under hacktoberfest and let me know if any changes are needed thank you.


