### PR TITLE
Fix: Corrected the padding of 'Get In Touch' header in Contact Us Page

### DIFF
--- a/css/contactUs.css
+++ b/css/contactUs.css
@@ -124,7 +124,8 @@ body {
 /* Hero Section */
 .hero {
     background: var(--bg-secondary);
-    padding: 80px 40px;
+    padding: 60px 40px;
+    padding-top: 150px;
     text-align: center;
 }
 


### PR DESCRIPTION
Solved Issue #202 
Corrected the padding of 'Get In Touch' header in Contact Us Page

After Change:
<img width="1901" height="921" alt="image" src="https://github.com/user-attachments/assets/35d6f250-94c4-43c7-939c-b1a740b93ac7" />

Before Change:
<img width="1911" height="928" alt="Screenshot 2025-10-16 173112" src="https://github.com/user-attachments/assets/5bedcfac-c035-4635-8814-561ecb7569ee" />