### PR TITLE
Remove social media duplication

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -83,23 +83,9 @@
             <div class="hero-section flex wrapper">
                 <div class="content">
                     <h1>Enjoy Your Delicious <span>Food</span></h1>
-                    <p class="para">We will fill your tummy with delicious <br> food with fast delivery</p>
+                    <p class="para">We will fill your tummy with delicious food with fast delivery</p>
                     <div class="flex gap-2">
                         <a href="./menu.html" class="place-order-btn btn">Order now</a>
-                        <div class="media flex gap-2">
-                            <a href="https://github.com/janavipandole" class="social-media">
-                                <img src="../imgs/GitHub.png" alt="GitHub profile link icon">
-                            </a>
-                            <a href="https://www.linkedin.com/in/janavi-pandole-80a7b2290" class="social-media linkdin">
-                                <img src="../imgs/linkdin.png" alt="LinkedIn profile link icon">
-                            </a>
-                            <a href="https://www.youtube.com/@JanaviPandole" class="social-media">
-                                <img src="../imgs/youtube.png" alt="YouTube channel link icon">
-                            </a>
-                            <a href="https://x.com/JanaviPandole" class="social-media">
-                                <img src="../imgs/twitter.png" alt="Twitter profile link icon">
-                            </a>
-                        </div>
                     </div>
                 </div>
                 <div class="image-container">


### PR DESCRIPTION
I had moved the social media icons from the hero section to the footer to eliminate duplication and streamline the layout.

### **THEN**
-----
<img width="900" height="916" alt="Screenshot 2025-10-16 193736" src="https://github.com/user-attachments/assets/74916c43-a689-427f-8d7b-f4e9f8075fcd" />


<img width="900" height="923" alt="Screenshot 2025-10-16 193753" src="https://github.com/user-attachments/assets/cab558fd-0860-4e19-a157-95669d4483d2" />

### **NOW**
-----

<img width="900" height="918" alt="Screenshot 2025-10-16 202204" src="https://github.com/user-attachments/assets/a190c46a-c39c-45f0-aafa-a7fa0914d509" />

@janavipandole can you assign this under hacktober-fest thank you
