### PR TITLE
Fix Footer: separate pages for Support section links

### DIFF
--- a/html/feedback.html
+++ b/html/feedback.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Feedback</title>
+</head>
+<body>
+
+    <!-- Hero Section -->
+    <section class="hero">
+        <h1>Give Your <span class="highlight">Feedback</span></h1>
+        <p>We would love to hear your thoughts about our services.</p>
+    </section>
+
+    <!-- Feedback Content -->
+    <section class="feedback-container">
+        <div class="feedback-card">
+            <h2>Website Feedback</h2>
+            <p>Tell us what you think about our website and navigation.</p>
+        </div>
+        <div class="feedback-card">
+            <h2>App Feedback</h2>
+            <p>Share your experience with our mobile application.</p>
+        </div>
+        <div class="feedback-card">
+            <h2>Service Feedback</h2>
+            <p>Let us know how we can improve food delivery and support.</p>
+        </div>
+    </section>
+
+    <!-- Footer (reuse from main footer) -->
+    <footer>
+        <p>&copy; 2025 Foodie. All Rights Reserved.</p>
+    </footer>
+
+</body>
+</html>
+

--- a/html/supportCenter.html
+++ b/html/supportCenter.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Support Center</title>
+</head>
+<body>
+
+    <!-- Hero Section -->
+    <section class="hero">
+        <h1>Welcome to <span class="highlight">Support Center</span></h1>
+        <p>Find answers to your questions and get help with our services.</p>
+    </section>
+
+    <!-- Support Content -->
+    <section class="support-container">
+        <div class="support-card">
+            <h2>Account Issues</h2>
+            <p>Manage your account, reset password, and update your info.</p>
+        </div>
+        <div class="support-card">
+            <h2>Order Problems</h2>
+            <p>Report missing items, late delivery, or other order issues.</p>
+        </div>
+        <div class="support-card">
+            <h2>General Help</h2>
+            <p>Get assistance with general questions about our app and services.</p>
+        </div>
+    </section>
+
+    <!-- Footer (reuse from main footer) -->
+    <footer>
+        <p>&copy; 2025 Foodie. All Rights Reserved.</p>
+    </footer>
+
+</body>
+</html>


### PR DESCRIPTION
This PR fixes the Support section in the footer by creating dedicated pages for each link.

Changes:
- Support Center → supportCenter.html
- Feedback → feedback.html
- Contacts → contactUs.html (unchanged)
- Updated footer links accordingly

Tested:
- Verified all Support section links navigate correctly.
