### PR TITLE
Fix: updated email placeholder in form

### DIFF
--- a/html/contactUs.html
+++ b/html/contactUs.html
@@ -144,7 +144,7 @@
                 <div class="form-row">
                     <div class="form-group">
                         <label for="email">Email Address *</label>
-                        <input type="email" id="email" placeholder="your@email.com" required>
+                        <input type="text" id="email" placeholder="your@email.com" required>
                     </div>
                     <div class="form-group">
                         <label for="phone">Phone Number</label>


### PR DESCRIPTION
This PR updates the placeholder text for the email input field in the send us a message form in Contact Us page to ensure better clarity and user experience. 

### **THEN**
<img width="450" height="600" alt="Screenshot 2025-10-17 083413" src="https://github.com/user-attachments/assets/0072a520-2c56-48eb-9903-053540c46530" />

<hr>

### **NOW**
<img width="450" height="600" alt="Screenshot 2025-10-17 083712" src="https://github.com/user-attachments/assets/ebea86c8-6016-4e25-8f56-c154e54a7251" />

@janavipandole can you assign under hacktober-fest