### PR TITLE
Fix: Browse Menu button redirection issue on checkout page

### DIFF
--- a/html/checkout.html
+++ b/html/checkout.html
@@ -80,7 +80,7 @@
       <i class="fa-solid fa-cart-shopping"></i>
       <h2>Your cart is empty</h2>
       <p>Add some delicious items to get started!</p>
-      <a href="./index.html#menu" class="btn">Browse Menu</a>
+      <a href="./menu.html" class="btn">Browse Menu</a>
     </div>
 
     <!-- CHECKOUT CONTENT -->


### PR DESCRIPTION
This PR Resolved an issue on the checkout page where clicking on the the 'Browse Menu' button  was not redirecting to the menu page. I had Updated the anchor/link logic in [`checkout.html`](https://github.com/janavipandole/Hacktoberfest2025-Foodie/blob/main/html/checkout.html) to ensure proper navigation.

- **File modified:** [html/checkout.html](https://github.com/janavipandole/Hacktoberfest2025-Foodie/blob/main/html/checkout.html)  
-  The redirection from checkout page now correctly points to the menu page  
@janavipandole can you please assign under hacktober-fest