### PR TITLE
fix: adjust cursor blend mode for light and dark themes 

### DIFF
--- a/css/cursor.css
+++ b/css/cursor.css
@@ -21,7 +21,7 @@
     left: 0;
     pointer-events: none;
     z-index: 9999;
-    mix-blend-mode: difference;
+    /* mix-blend-mode: difference; */
 }
 
 /* Main Cursor Dot (Glassmorphism) */


### PR DESCRIPTION
Fixes : #248 

before--
<img width="1919" height="872" alt="Screenshot 2025-10-22 154108" src="https://github.com/user-attachments/assets/2fa55729-e3ae-4f59-a2c0-992be97c9a96" />

after--
<img width="1919" height="866" alt="Screenshot 2025-10-22 154034" src="https://github.com/user-attachments/assets/fee38f90-d96f-4cc5-99d4-1ca25f202659" />
