### PR TITLE
chore(deploy): fix Vercel routing to serve /html pages while keeping assets at root

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,13 +1,8 @@
 {
   "version": 2,
-  "builds": [
-    { "src": "html/**/*.html", "use": "@vercel/static" },
-    { "src": "css/**/*", "use": "@vercel/static" },
-    { "src": "js/**/*", "use": "@vercel/static" },
-    { "src": "imgs/**/*", "use": "@vercel/static" }
-  ],
   "routes": [
-    { "src": "/", "dest": "/html/index.html" },
-    { "src": "/(.*)", "dest": "/html/$1" }
+    { "handle": "filesystem" },
+    { "src": "^/$", "dest": "/html/index.html" },
+    { "src": "^/([^/]+)\\.html$", "dest": "/html/$1.html" }
   ]
 }


### PR DESCRIPTION
## Summary
This PR updates `vercel.json` with a minimal, configuration-only fix so Vercel serves the site correctly when HTML files live under `/html` and static assets (`/css`, `/js`, `/imgs`) remain at the repository root.

## Problem
- The previous routing matched all paths to `/html/$1`, which unintentionally rewrote requests for assets (e.g., `/css/style.css`, `/js/app.js`) and caused 404s on Vercel.
- Vercel deployment failed/intermittently rendered without CSS/JS due to those rewrites.

## What changed
- Use a filesystem-first rule so Vercel serves existing files (assets) from the root as-is.
- Add explicit routes for only HTML pages:
  - `/` ➜ `/html/index.html`
  - `/*.html` ➜ `/html/*.html`

Result: HTML is served from `/html`, assets continue to resolve from root without rewrites.

### vercel.json
```json
{
  "version": 2,
  "routes": [
    { "handle": "filesystem" },
    { "src": "^/$", "dest": "/html/index.html" },
    { "src": "^/([^/]+)\\.html$", "dest": "/html/$1.html" }
  ]
}
```

## How it works
- `{ "handle": "filesystem" }` tells Vercel to serve any real files from the repo root directly (e.g., `/css/*`, `/js/*`, `/imgs/*`).
- Only two rewrite rules remain, and both apply to HTML routes, mapping them into `/html`.

## Verification
After deploy, verify these URLs in the Vercel preview:
- `/` returns the homepage (200) and loads CSS/JS without 404s
- `/aboutUs.html`, `/menu.html`, `/contactUs.html`, etc. render correctly (200)
- DevTools Network tab shows CSS/JS served from `/css/*` and `/js/*` without rewrites

## Deployment notes
Vercel Project Settings (for static hosting):
- Framework Preset: "Other"
- Build Command: empty (none)
- Output Directory: empty (repo root)
- Root Directory: repository root (not `/html`)

No build step is required for this static site.

## Risks / Trade-offs
- Assumes HTML files are top-level under `/html` (e.g., `/html/aboutUs.html`). If nested HTML routes are added later, we can extend the regex or add additional rules.
- Does not move/rename any files—keeps repo structure intact.

## Checklist
- [x] Config-only change
- [x] No breaking changes
- [x] Verified routing locally/by inspection

## Maintainers
- Please add the `Hacktoberfest` label; on merge, consider `hacktoberfest-accepted`.
- CC: @janavipandole 
