### PR TITLE
fix: improve CTA button visibility by using black background

### DIFF
--- a/css/aboutUs.css
+++ b/css/aboutUs.css
@@ -501,7 +501,7 @@ p {
 }
 
 .cta-btn.primary {
-    background: var(--lead);
+    background: black;
     color: var(--pure-white);
 }
 


### PR DESCRIPTION
Improved button visibility in the CTA section by changing .cta-btn.primary background to black for better contrast and accessibility compliance.

Before:
<img width="1041" height="395" alt="image" src="https://github.com/user-attachments/assets/b54188db-8095-41f4-8e5a-7e4a76bcfb85" />

After:
<img width="1919" height="866" alt="image" src="https://github.com/user-attachments/assets/07886c04-fc9b-46ad-a3c0-5d590b4c3f2c" />

Fix #292 