### PR TITLE
fix: improved buttons visibility in light mode on About Us page (CTA section)

### DIFF
--- a/css/aboutUs.css
+++ b/css/aboutUs.css
@@ -513,7 +513,7 @@ p {
 
 .cta-btn.primary {
     background: black;
-    color: var(--pure-white);
+    color: white;
 }
 
 .cta-btn.primary:hover {


### PR DESCRIPTION
### This pull request resolves the issue where the "Sign Up Now" and "Browse Menu" buttons on the About Us page are not visible or readable in light mode due to insufficient color contrast.

**before:**
<img width="1607" height="617" alt="image" src="https://github.com/user-attachments/assets/d21de0e2-2c17-425d-9e01-a5212b9bea4e" />

**after:**
<img width="1652" height="638" alt="image" src="https://github.com/user-attachments/assets/18907bc4-507b-41e6-839e-fab5b7bf645c" />
