### PR TITLE
fix : cards text contrast on about us page

### DIFF
--- a/css/aboutUs.css
+++ b/css/aboutUs.css
@@ -293,7 +293,7 @@ p {
 .mission-back {
   transform: rotateY(180deg);
   background: linear-gradient(135deg, var(--gold-finger), #ffb84d);
-  color: #fff;
+  color: #fff; /* This color is for the entire back card, but the paragraph text needs to be dark */
   display: flex;
   align-items: center;
   justify-content: center;
@@ -309,6 +309,7 @@ p {
   line-height: 1.4;
   word-wrap: break-word;
   width: 90%;
+  color: black; /* Changed to black for better contrast */
 }
 
 /* ===========================


### PR DESCRIPTION
## closes #426 

## Description
The text inside the “Our Mission,” “Our Vision,” and “Our Values” cards is super hard to read. The contrast between the background and the card text is way too low, especially on the Mission card where the yellow text blends into the glowing background. Basically, my eyes are doing parkour trying to decipher it.

## Screenshot
<img width="1903" height="894" alt="image" src="https://github.com/user-attachments/assets/eb9f1ca1-38a7-4641-ac7c-c788f9ffbd68" />
