### PR TITLE
Fixed i18n Keys by improving i18n.js file.

### DIFF
--- a/js/i18n.js
+++ b/js/i18n.js
@@ -16,7 +16,7 @@ class I18n {
     // Corrected translation path + optimized fallback handling
     async loadTranslations(lang) {
         try {
-            const response = await fetch(`./locales/${lang}.json`);
+            const response = await fetch(`/locales/${lang}.json`);
 
             if (!response.ok) {
                 throw new Error(`Could not load: ${lang}.json`);


### PR DESCRIPTION
@janavipandole Please review this and if you find it correct then please merge this.
 I have improved i18n.js file.
Here is the previous issue it was showing:

Navbar: nav.home, nav.menu, nav.contact, etc.
Hero section: Hero.Title, hero.subtitle
Search bar: nav.searchPlaceholder

Here is the corrected version:
All i18n keys should be replaced with proper translated text (e.g., Home, Menu, Contact, Order Now).
<img width="1898" height="1004" alt="Screenshot 2025-11-23 234036" src="https://github.com/user-attachments/assets/394a1548-73e8-4bed-8491-b33310f80f10" />
