### PR TITLE
fix: navbar wrapping issue

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -221,6 +221,17 @@
         max-width: 100% !important;
         padding-inline: 3rem !important;
     }
+    .navbar {
+        flex-wrap: nowrap !important;
+    }
+    .navbar-search input {
+        width: 150px !important; /* reduce width */
+    }
+
+    .custom-select {
+        width: 110px !important; /* language select shorter */
+    }
+
 
     /* Hover effect for navbar links */
     .navList a {
@@ -2094,7 +2105,7 @@
     animation: qrPulse 2s infinite;
 }
 
-/* Smooth entrance animation */
+
 .app-download-content {
     animation: slideInRight 0.8s ease-out;
 }
@@ -2109,3 +2120,20 @@
         transform: translateX(0);
     }
 }
+@media (max-width: 1150px) and (min-width: 801px) {
+    .desktop-action .btn {        
+        display: none;
+    }
+    .navbar-search {         
+        display: none;
+    }
+    .custom-select {                
+        display: none;
+    }
+}
+    .desktop-action {
+        gap: 0.7rem !important;
+    }
+    .navList {
+        gap: 1.5rem !important;
+    }

--- a/html/aboutUs.html
+++ b/html/aboutUs.html
@@ -441,6 +441,8 @@
     <script src="../js/footer.js"></script>
     <script src="../js/cursor.js"></script>
     <script src="../js/app.js"></script>
+    <script src="../js/i18n.js"></script>
+
 </body>
 
 </html>

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -16,7 +16,10 @@ class I18n {
     // Corrected translation path + optimized fallback handling
     async loadTranslations(lang) {
         try {
-            const response = await fetch(`/locales/${lang}.json`);
+            const isInsideHTML = window.location.pathname.includes("/html/");
+            const basePath = isInsideHTML ? "../js/locales/" : "./js/locales/";
+            const response = await fetch(`${basePath}${lang}.json`);
+
 
             if (!response.ok) {
                 throw new Error(`Could not load: ${lang}.json`);


### PR DESCRIPTION
### **Fix: Improved navbar to prevent two-line wrapping and enhance responsiveness**

###  **Description:**

The navbar was breaking into two lines on medium screen sizes, making the layout inconsistent and hard to read.
I updated the CSS to keep all navbar items on a single line, adjusted spacing, and added responsive rules to ensure the navbar remains clean and usable across all screen sizes.

This improves readability and maintains a stable UI on all pages.

Fixes #468 

### Before:
<img width="1365" height="689" alt="image" src="https://github.com/user-attachments/assets/ab4f428e-c3f7-4f4b-9720-bdd730f35e45" />


Navbar breaking into two lines and overflowing.


### After:

<img width="1364" height="644" alt="image" src="https://github.com/user-attachments/assets/8c666e51-35b7-4f0b-8787-6770c1566020" />

Navbar stays in one line, fully responsive, clean layout.

Thank you!