### PR TITLE
Added bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,35 @@
+name: "🐞 Bug Report"
+description: "Report a bug or unexpected behavior in the project"
+title: "[BUG] "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: "Description"
+      description: "Describe the bug clearly and concisely."
+      placeholder: "Steps to reproduce, observed behavior, expected behavior..."
+  - type: textarea
+    id: steps
+    attributes:
+      label: "Steps to Reproduce"
+      description: "List steps to reproduce the issue."
+      placeholder: "1. Go to ...\n2. Click ...\n3. Observe ..."
+  - type: textarea
+    id: expected
+    attributes:
+      label: "Expected Behavior"
+      description: "What you expected to happen."
+  - type: textarea
+    id: actual
+    attributes:
+      label: "Actual Behavior"
+      description: "What actually happened."
+  - type: dropdown
+    id: severity
+    attributes:
+      label: "Severity"
+      options:
+        - Low
+        - Medium
+        - High


### PR DESCRIPTION
CLOSES : #473 

## 🐞 Added Bug Report Issue Template

This PR introduces a structured Bug Report issue template to ensure contributors provide clear and actionable information when reporting issues.

### 🔧 Highlights
- Added `bug_report.yml` under `.github/ISSUE_TEMPLATE/`
- Includes fields for steps to reproduce, expected behavior, logs, and environment
- Helps maintain consistent and detailed bug submissions

### 🎯 Impact
Improves debugging workflow and reduces follow-up questions in issue threads.
