### PR TITLE
 remove nav. prefix from navbar data-i18n attributes.

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -71,11 +71,11 @@
             <a href="index.html" class="logo">Foodie.</a>
 
             <ul class="navList flex gap-3 between">
-                <li><a class="active" href="./index.html#home" data-i18n="nav.home">Home</a></li>
-                <li><a href="./menu.html" data-i18n="nav.menu">Menu</a></li>
-                <li><a href="./aboutUs.html" data-i18n="nav.about">About Us</a></li>
-                <li><a href="./contactUs.html" data-i18n="nav.contact">Contact Us</a></li>
-                <li><a href="nearbyres.html" data-i18n="nav.nearby">Nearby Restaurants</a></li>
+                <li><a class="active" href="./index.html#home" data-i18n=".home">Home</a></li>
+                <li><a href="./menu.html" data-i18n=".menu">Menu</a></li>
+                <li><a href="./aboutUs.html" data-i18n=".about">About Us</a></li>
+                <li><a href="./contactUs.html" data-i18n=".contact">Contact Us</a></li>
+                <li><a href="nearbyres.html" data-i18n=".nearby">Nearby Restaurants</a></li>
             </ul>
             <div class="desktop-action flex gap-2">
                 <div class="custom-select" id="language-custom-select">
@@ -107,7 +107,7 @@
                     <span class="cart-value">0</span>
                 </a>
 
-                <a href="./signup.html" class="btn" data-i18n="nav.signIn">
+                <a href="./signup.html" class="btn" data-i18n=".signIn">
                     Sign in&nbsp;<i class="fa-solid fa-arrow-right-from-bracket"></i>
                 </a>
 
@@ -117,11 +117,11 @@
 
 
             <ul class="mobile-menu">
-                <li><a class="active" href="./index.html#home" data-i18n="nav.home">Home</a></li>
-                <li><a href="./menu.html" data-i18n="nav.menu">Menu</a></li>
-                <li><a href="./aboutUs.html" data-i18n="nav.about">About Us</a></li>
-                <li><a href="./contactUs.html" data-i18n="nav.contact">Contact Us</a></li>
-                <li><a href="nearbyres.html" data-i18n="nav.nearby">Nearby Restaurants</a></li>
+                <li><a class="active" href="./index.html#home" data-i18n="home">Home</a></li>
+                <li><a href="./menu.html" data-i18n="menu">Menu</a></li>
+                <li><a href="./aboutUs.html" data-i18n="about">About Us</a></li>
+                <li><a href="./contactUs.html" data-i18n="contact">Contact Us</a></li>
+                <li><a href="nearbyres.html" data-i18n="nearby">Nearby Restaurants</a></li>
                 <form class="navbar-search" action="#" method="get">
                     <input type="text" name="search" id="navbar-search" placeholder="Search your food ...">
                     <button type="submit" id="navbar-search-btn" aria-label="Search">


### PR DESCRIPTION
Fixes #490 - removed unnecessary nav. prefix from all data-i18n attributes in navbar.

## 📝 Description
Removed the `nav.` prefix from all `data-i18n` attributes in the navbar so they display correctly instead of showing raw translation keys.


## 🔗 Related Issue
Closes #490

## 🛠 Changes
- Removed `nav.` prefix from `data-i18n="nav.home"` → `data-i18n="home"`
- Removed `nav.` prefix from `data-i18n="nav.menu"` → `data-i18n="menu"`
- Removed `nav.` prefix from `data-i18n="nav.about"` → `data-i18n="about"`
- Removed `nav.` prefix from `data-i18n="nav.contact"` → `data-i18n="contact"`
- Removed `nav.` prefix from `data-i18n="nav.nearby"` → `data-i18n="nearby"`

## ✅ Checklist
- [ ] My code follows the project guidelines.
- [ ] I have tested the changes.
- [ ] Documentation updated if needed.
- [ ] PR title is descriptive.

## 📷 Screenshots (optional)
