### PR TITLE
fix: correct Home navbar i18n keys to remove dot-prefixed labels #544

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -71,11 +71,11 @@
             <a href="index.html" class="logo">Foodie.</a>
 
             <ul class="navList flex gap-3 between">
-                <li><a class="active" href="./index.html#home" data-i18n=".home">Home</a></li>
-                <li><a href="./menu.html" data-i18n=".menu">Menu</a></li>
-                <li><a href="./aboutUs.html" data-i18n=".about">About Us</a></li>
-                <li><a href="./contactUs.html" data-i18n=".contact">Contact Us</a></li>
-                <li><a href="nearbyres.html" data-i18n=".nearby">Nearby Restaurants</a></li>
+                <li><a class="active" href="./index.html#home" data-i18n="nav.home">Home</a></li>
+                <li><a href="./menu.html" data-i18n="nav.menu">Menu</a></li>
+                <li><a href="./aboutUs.html" data-i18n="nav.about">About Us</a></li>
+                <li><a href="./contactUs.html" data-i18n="nav.contact">Contact Us</a></li>
+                <li><a href="nearbyres.html" data-i18n="nav.nearby">Nearby Restaurants</a></li>
             </ul>
             <div class="desktop-action flex gap-2">
                 <div class="custom-select" id="language-custom-select">
@@ -108,7 +108,7 @@
                     <span class="cart-value">0</span>
                 </a>
 
-                <a href="./signup.html" class="btn" data-i18n=".signIn">
+                <a href="./signup.html" class="btn" data-i18n="nav.signIn">
                     Sign in&nbsp;<i class="fa-solid fa-arrow-right-from-bracket"></i>
                 </a>
 
@@ -118,11 +118,11 @@
 
 
             <ul class="mobile-menu">
-                <li><a class="active" href="./index.html#home" data-i18n="home">Home</a></li>
-                <li><a href="./menu.html" data-i18n="menu">Menu</a></li>
-                <li><a href="./aboutUs.html" data-i18n="about">About Us</a></li>
-                <li><a href="./contactUs.html" data-i18n="contact">Contact Us</a></li>
-                <li><a href="nearbyres.html" data-i18n="nearby">Nearby Restaurants</a></li>
+                <li><a class="active" href="./index.html#home" data-i18n="nav.home">Home</a></li>
+                <li><a href="./menu.html" data-i18n="nav.menu">Menu</a></li>
+                <li><a href="./aboutUs.html" data-i18n="nav.about">About Us</a></li>
+                <li><a href="./contactUs.html" data-i18n="nav.contact">Contact Us</a></li>
+                <li><a href="nearbyres.html" data-i18n="nav.nearby">Nearby Restaurants</a></li>
                 <form class="navbar-search" action="#" method="get">
                     <input type="text" name="search" id="navbar-search" placeholder="Search your food ...">
                     <button type="submit" id="navbar-search-btn" aria-label="Search">


### PR DESCRIPTION
Closes #544

## Summary
Fixed incorrect navigation labels in the Home section where menu items were showing malformed text like `.home`, `.menu`, `.about`, `.contact`, `.nearby`.

## 🛠️ What Was Fixed
- Updated desktop navbar i18n keys in `html/index.html`:
  - `.home` -> `nav.home`
  - `.menu` -> `nav.menu`
  - `.about` -> `nav.about`
  - `.contact` -> `nav.contact`
  - `.nearby` -> `nav.nearby`
- Updated Sign In key:
  - `.signIn` -> `nav.signIn`
- Updated mobile navbar keys to consistently use `nav.*` namespace:
  - `home/menu/about/contact/nearby` -> `nav.home/nav.menu/nav.about/nav.contact/nav.nearby`

## Result
Navbar labels now display correctly as:
- Home
- Menu
- About Us
- Contact Us
- Nearby Restaurants

No more dot-prefixed labels in the Home navigation.