### PR TITLE
ci: add workflow to auto-label new issues with NSoC'26

### DIFF
--- a/.github/workflows/auto-label-nsoc-issues.yml
+++ b/.github/workflows/auto-label-nsoc-issues.yml
@@ -1,0 +1,55 @@
+name: Auto Label Issues (NSoC'26)
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  add-nsoc-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure label exists
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labelName = "NSoC'26";
+            const labelColor = "1D76DB";
+            const labelDescription = "Issue opened for Nexus Spring of Code 2026";
+
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: labelName,
+              });
+              core.info(`Label '${labelName}' already exists.`);
+            } catch (error) {
+              if (error.status === 404) {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: labelName,
+                  color: labelColor,
+                  description: labelDescription,
+                });
+                core.info(`Created label '${labelName}'.`);
+              } else {
+                throw error;
+              }
+            }
+
+      - name: Add NSoC label to new issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labelName = "NSoC'26";
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              labels: [labelName],
+            });
+            core.info(`Added '${labelName}' to issue #${context.payload.issue.number}.`);


### PR DESCRIPTION
📝 Description
Adds a GitHub Actions workflow to automatically apply the NSoC'26 label whenever a new issue is opened.
The workflow also creates the label if it does not already exist.

🔗 Related Issue
Closes #589 

🛠 Changes
Added workflow: .github/workflows/auto-label-nsoc-issues.yml
Trigger: issues opened
Added logic to create NSoC'26 label if missing
Added logic to apply NSoC'26 label to each new issue

✅ Checklist
 My code follows the project guidelines.
 I have tested the changes.
 Documentation updated if needed.
 PR title is descriptive.

📷 Screenshots (optional)
N/A
