### PR TITLE
Badges

### DIFF
--- a/css/order-history.css
+++ b/css/order-history.css
@@ -117,6 +117,21 @@
   color: #721c24;
 }
 
+.status-processing {
+  background: #cce5ff;
+  color: #004085;
+}
+
+.status-shipped {
+  background: #e2d9f3;
+  color: #432874;
+}
+
+.status-refunded {
+  background: #e2e3e5;
+  color: #383d41;
+}
+
 .order-timestamp {
   color: var(--text-muted);
   font-size: 0.9rem;

--- a/css/order-history.css
+++ b/css/order-history.css
@@ -315,3 +315,30 @@
 [data-theme="dark"] .order-delivery-info {
   background: var(--bg-color);
 }
+
+[data-theme="dark"] .status-delivered {
+  background: #1a3a25; color: #75c98a; 
+}
+
+[data-theme="dark"] .status-pending   { 
+  background: #3a2f00; color: #ffc94d; 
+}
+
+[data-theme="dark"] .status-cancelled { 
+  background: #3a0a0f; color: #f07070; 
+}
+
+[data-theme="dark"] .status-processing {
+  background: #003366;
+  color: #66b2ff;
+}
+
+[data-theme="dark"] .status-shipped {
+  background: #2a1a4a;
+  color: #c9a8f5;
+}
+
+[data-theme="dark"] .status-refunded {
+  background: #2a2a2a;
+  color: #b0b0b0;
+}


### PR DESCRIPTION
## 📝 Description
This PR does two things:
1. Adds the three missing order status badge styles — _processing_, _shipped_, and _refunded_
2. Adds dark mode overrides for all six status badges


## 🔗 Related Issue
Closes #595 

## Problem

The codebase only had styles for three order statuses (_delivered, pending, cancelled_). Two issues existed:

- **Missing statuses** — _processing, shipped_, and _refunded_ had no _.status-*_ class defined at all. Rendering these would produce an unstyled, broken badge
- **No dark mode support** — all three existing badges used hardcoded light pastel colors with no _[data-theme="dark"]_ override, causing them to look visually inconsistent on dark themed screens

## 🛠 Changes
**order-history.css**

Added three new light mode status badge styles:
```
.status-processing { background: #cce5ff; color: #004085; }
.status-shipped    { background: #e2d9f3; color: #432874; }
.status-refunded   { background: #e2e3e5; color: #383d41; }

```

Added dark mode overrides for all six statuses:
```
[data-theme="dark"] .status-delivered  { background: #1a3a25; color: #75c98a; }
[data-theme="dark"] .status-pending    { background: #3a2f00; color: #ffc94d; }
[data-theme="dark"] .status-cancelled  { background: #3a0a0f; color: #f07070; }
[data-theme="dark"] .status-processing { background: #002a52; color: #6db8ff; }
[data-theme="dark"] .status-shipped    { background: #1e0a3a; color: #c49fef; }
[data-theme="dark"] .status-refunded   { background: #1a1c1e; color: #b0b3b8; }

```

## ✅ Checklist
- [x] My code follows the project guidelines.
- [x] I have tested the changes.
- [x] Documentation updated if needed.
- [x] PR title is descriptive.


