### PR TITLE
Fix theme toggle race condition and harden against edge cases

### DIFF
--- a/js/forgot-password.js
+++ b/js/forgot-password.js
@@ -5,8 +5,10 @@ document.addEventListener('DOMContentLoaded', () => {
   ========================== */
 
   const themeToggle = document.getElementById('themeToggle');
+  if (!themeToggle) return;
   const html = document.documentElement;
   const themeIcon = themeToggle.querySelector('i');
+  if (!themeIcon) return;
 
   // Detect system theme
   const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;

--- a/js/forgot-password.js
+++ b/js/forgot-password.js
@@ -59,6 +59,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
   function updateThemeIcon(theme) {
+    if (!themeIcon) return;
     if (theme === 'dark') {
       themeIcon.classList.remove('fa-moon');
       themeIcon.classList.add('fa-sun');
@@ -66,6 +67,8 @@ document.addEventListener('DOMContentLoaded', () => {
       themeIcon.classList.remove('fa-sun');
       themeIcon.classList.add('fa-moon');
     }
+    themeToggle.setAttribute('aria-pressed', theme === 'dark');
+    themeToggle.setAttribute('aria-label', `Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`);
   }
 
   /* =========================

--- a/js/forgot-password.js
+++ b/js/forgot-password.js
@@ -51,6 +51,13 @@ document.addEventListener('DOMContentLoaded', () => {
     }, 600);
   });
 
+  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+    if (!localStorage.getItem('theme')) {
+      const newTheme = e.matches ? 'dark' : 'light';
+      html.setAttribute('data-theme', newTheme);
+      updateThemeIcon(newTheme);
+    }
+  });
   function updateThemeIcon(theme) {
     if (theme === 'dark') {
       themeIcon.classList.remove('fa-moon');

--- a/js/forgot-password.js
+++ b/js/forgot-password.js
@@ -19,7 +19,14 @@ document.addEventListener('DOMContentLoaded', () => {
   updateThemeIcon(currentTheme);
 
   // Theme toggle click
+  let rotateTimeout = null;
   themeToggle.addEventListener('click', () => {
+    if (rotateTimeout) {
+      clearTimeout(rotateTimeout);
+      rotateTimeout = null;
+      themeIcon.classList.remove('rotate-icon');
+      html.classList.remove('theme-transition');
+    }
     html.classList.add('theme-transition');
 
     const activeTheme = html.getAttribute('data-theme');

--- a/js/forgot-password.js
+++ b/js/forgot-password.js
@@ -33,7 +33,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const newTheme = activeTheme === 'light' ? 'dark' : 'light';
 
     html.setAttribute('data-theme', newTheme);
-    localStorage.setItem('theme', newTheme);
+    try {
+      localStorage.setItem('theme', newTheme);
+    } catch (err) {
+      console.warn('[themeToggle] Could not persist theme:', err);
+    }
     updateThemeIcon(newTheme);
 
     themeIcon.classList.add('rotate-icon');

--- a/js/forgot-password.js
+++ b/js/forgot-password.js
@@ -42,9 +42,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
     themeIcon.classList.add('rotate-icon');
 
-    setTimeout(() => {
+    rotateTimeout = setTimeout(() => {
       html.classList.remove('theme-transition');
       themeIcon.classList.remove('rotate-icon');
+      rotateTimeout = null;
     }, 600);
   });
 


### PR DESCRIPTION
## 📝 Description
Fixes the setTimeout race condition on rapid clicks and hardens the theme toggle against every identified edge case — null elements, private browsing, OS theme changes, and missing accessibility state. All changes are isolated to the theme toggle section only.


## 🔗 Related Issue
Closes #597 

## 🛠 Changes

- Race condition fix — add` let rotateTimeout = null `directly above the click listener, then as the very first line inside it
- Store `setTimeout` reference — replace `setTimeout(` with `rotateTimeout = setTimeout(` and add `rotateTimeout = null` as the last line inside the callback
- `localStorage` try/catch — replace `localStorage.setItem('theme', newTheme)` with
```
try {
  localStorage.setItem('theme', newTheme);
} catch (err) {
  console.warn('[themeToggle] Could not persist theme to localStorage:', err);
}
```

- OS theme listener — add before function `updateThemeIcon`
```
window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
  if (!localStorage.getItem('theme')) {
    const newTheme = e.matches ? 'dark' : 'light';
    html.setAttribute('data-theme', newTheme);
    updateThemeIcon(newTheme);
  }
});
```

- `aria-pressed` + `aria-label` — append at the bottom of `updateThemeIcon`
- Null guard inside `updateThemeIcon` — add as the very first line



## ✅ Checklist
- [x] My code follows the project guidelines.
- [x] I have tested the changes.
- [x] Documentation updated if needed.
- [x] PR title is descriptive.


