### PR TITLE
Fix: Prevent crash when category container is missing

### DIFF
--- a/js/category.js
+++ b/js/category.js
@@ -54,6 +54,9 @@ function showRetryButton(container, retryFn, message = 'Retry') {
 async function loadCategories() {
     const container = document.getElementById('categoryContainer');
 
+    //FIX: Prevent crasg if container is missing
+    if (!container) return;
+
     try {
         setLoadingState(container, true, 'Loading cuisines...');
 

--- a/js/category.js
+++ b/js/category.js
@@ -54,7 +54,7 @@ function showRetryButton(container, retryFn, message = 'Retry') {
 async function loadCategories() {
     const container = document.getElementById('categoryContainer');
 
-    //FIX: Prevent crasg if container is missing
+    //FIX: Prevent crash if container is missing
     if (!container) return;
 
     try {


### PR DESCRIPTION
## 📝 Description
This PR adds a safety check in `loadCategories()`  to ensure the function does not execute DOM operations when `categoryContainer` is not present.

## 🔗 Related Issue
Closes #604 

## 🛠 Changes

- Added null check for categoryContainer
- Prevents runtime crash on pages without category UI
- Improves script reusability across multiple pages

Previously, calling `loadCategories()` on a page without the container caused:

1. `TypeError: Cannot set properties of null`
2. Full function failure.

This fix makes the function safe and non-blocking.

 
## ✅ Checklist
[x] Prevents runtime crash
[x] Safe DOM handling added
[x] No breaking changes
[x] Backward compatible


