### PR TITLE
fix: remove SyntaxError caused by invalid placeholder and misplaced closure in app.js

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -448,7 +448,6 @@ const addToCart = (product, card) => {
     cartList.appendChild(cartItem);
     updateTotalPrice();
     saveCart();
-};
 
     const plusBtn = cartItem.querySelector('.plus');
     const minusBtn = cartItem.querySelector('.minus');
@@ -485,6 +484,7 @@ const addToCart = (product, card) => {
     // Update the card button to show quantity selector
     updateCardButton(card, product);
 });
+};
 
 // ===== CHECKOUT =====
 const checkoutBtn = document.querySelector('.check-out');
@@ -1087,5 +1087,4 @@ const restoreCartFromStorage = () => {
         });
     }
 };
-window.addEventListener("load", () => { ... });
     


### PR DESCRIPTION
Closes #613

## What I did
- Removed `window.addEventListener("load", () => { ... })` at the bottom of `app.js` where the `...` was a literal placeholder causing a `SyntaxError`
- Fixed misplaced `};` in `addToCart` that was closing the function too early, leaving `plusBtn` and `minusBtn` event listeners as orphaned code outside the function
- Both issues combined were crashing the entire script before `showCards` could be defined, causing menu items to not render on the page

## Root Cause
Two syntax issues introduced in the same commit:
1. Orphaned event listeners outside `addToCart` due to early function closure
2. Literal `...` placeholder in a load event listener that was never implemented

No other changes to logic or behavior.

<img width="1919" height="1022" alt="Screenshot 2026-05-07 101758" src="https://github.com/user-attachments/assets/26f4acbb-9ffe-4311-bd89-244c83430239" />
