### PR TITLE
fix: remove duplicate faq grid causing layout issue

### DIFF
--- a/css/contactUs.css
+++ b/css/contactUs.css
@@ -166,6 +166,7 @@ select:focus {
     gap: 1.75rem;
     max-width: 1200px;
     margin: 0 auto;
+    padding: 0 1rem;
 }
 
 .faq-item {
@@ -214,11 +215,6 @@ select:focus {
     background: var(--accent-secondary);
 }
 
-.faq-grid {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem; /* consistent spacing between items */
-}
 
 .faq-item {
   

--- a/css/contactUs.css
+++ b/css/contactUs.css
@@ -259,16 +259,6 @@ footer#contacts .footer-container {
 }
 
 
-@media (max-width: 900px) {
-    .faq-grid {
-        grid-template-columns: 1fr;
-    }
-
-    .faq-header h2 {
-        font-size: 2.2rem;
-    }
-}
-
 @media (prefers-reduced-motion: reduce) {
 
     .faq-item,
@@ -281,9 +271,13 @@ footer#contacts .footer-container {
 /* Responsive */
 @media (max-width: 1024px) {
 
-    .contact-container,
     .faq-grid {
         grid-template-columns: 1fr;
+        gap: 40px;
+    }
+
+    .contact-container {
+        flex-direction: column;
         gap: 40px;
     }
 }


### PR DESCRIPTION
### Description

This PR fixes a layout issue in the FAQ section caused by duplicate .faq-grid class definitions.

Previously,` .faq-grid` was defined twice:

One using CSS Grid (display: grid)
Another using Flexbox (display: flex)

Due to CSS cascading rules, the second definition (Flexbox) was overriding the first, preventing the intended grid layout from being applied.

### Changes Made
Removed duplicate `.faq-grid` definition using Flexbox:
**_Removed :_**
```
.faq-grid {
  display: flex;
  flex-direction: column;
  gap: 1rem;
}
```
Retained the Grid-based layout:
```
.faq-grid {
    display: grid;
    grid-template-columns: repeat(2, 1fr);
    gap: 1.75rem;
    max-width: 1200px;
    margin: 0 auto;
}
```
### Closed Issue
Closes #620 
Closes #621 

### Why this change is needed

- Fixes unintended layout override
- Restores correct 2-column grid layout on larger screens
- Improves code clarity and maintainability

### Testing
Open FAQ section
Verify:

- Desktop → 2-column layout
- Mobile → 1-column layout (via media query)
- Confirm display: grid is applied in DevTools

### Impact

- No breaking changes
- Layout is corrected as intended
- Improves maintainability

### Labels
🐛 bug
🎨 frontend
🧹 cleanup

### Checklist
- [x] My code follows the project guidelines.
- [x] I have tested the changes.
- [ ] Documentation updated if needed.
- [x] PR title is descriptive.
