### PR TITLE
Fix mobile navbar overflow by allowing wrapping and reducing header padding

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -228,6 +228,20 @@
         width: 150px !important; /* reduce width */
     }
 
+    /* Responsive fix: allow navbar to wrap and reduce header padding to avoid horizontal overflow */
+    @media (max-width: 768px) {
+        header .wrapper,
+        header .navbar.wrapper {
+            padding-inline: 1rem !important;
+        }
+        .navbar {
+            flex-wrap: wrap !important;
+        }
+        .navbar-search input {
+            width: 100px !important;
+        }
+    }
+
     .custom-select {
         width: 110px !important; /* language select shorter */
     }


### PR DESCRIPTION
# Related Issue
Closes #632 

# Summary
Adds a targeted responsive CSS fix to prevent horizontal overflow caused by non-wrapping navbar and large header paddings on mobile screens.

# Changes Made
- `css/style.css`: added a media query for `max-width: 768px` to allow navbar wrapping and reduce header padding and search input width.

# Testing
- Verified in responsive devtools (mobile widths) that the navbar wraps and horizontal overflow is resolved.
- Confirmed no visual regressions at desktop sizes.

# Checklist
* [x] CSS changes are minimal and scoped
* [x] Tested locally in browser/devtools
* [x] No unrelated files changed