### PR TITLE
perf: Add lazy loading to images to improve LCP

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -161,7 +161,7 @@
                 </div>
                 <div class="image-container" data-aos="fade-left">
                     <span class="pizza-pause-zone" aria-hidden="true"></span>
-                    <img src="../imgs/pizza.webp" alt="Delicious wood-fired pizza with fresh toppings" class="pizza-boy">
+                    <img src="../imgs/pizza.webp" alt="Delicious wood-fired pizza with fresh toppings" class="pizza-boy" loading="lazy">
                 </div>
             </div>
         </section>
@@ -175,7 +175,7 @@
                 <div class="flex text-center gap-4 mt-4">
                     <div class="srevice-card" data-aos="zoom-in" data-aos-delay="100">
                         <div>
-                            <img src="../imgs/easy-to-order.webp" alt="Easy food ordering">
+                            <img src="../imgs/easy-to-order.webp" alt="Easy food ordering" loading="lazy">
                         </div>
                         <h3 data-i18n="services.easyOrder.title">Easy to Order</h3>
                         <p data-i18n="services.easyOrder.description">You only need a few steps in ordering food.</p>
@@ -183,7 +183,7 @@
 
                     <div class="srevice-card" data-aos="zoom-in" data-aos-delay="200">
                         <div>
-                            <img src="../imgs/fast-delivery.webp" alt="Fast food delivery">
+                            <img src="../imgs/fast-delivery.webp" alt="Fast food delivery" loading="lazy">
                         </div>
                         <h3 data-i18n="services.fastDelivery.title">Fast delivery</h3>
                         <p data-i18n="services.fastDelivery.description">Delivery that is always on time, even faster.
@@ -192,7 +192,7 @@
 
                     <div class="srevice-card" data-aos="zoom-in" data-aos-delay="300">
                         <div>
-                            <img src="../imgs/best-quality.webp" alt="High-quality food service">
+                            <img src="../imgs/best-quality.webp" alt="High-quality food service" loading="lazy">
                         </div>
                         <h3 data-i18n="services.bestQuality.title">Best quality</h3>
                         <p data-i18n="services.bestQuality.description">Not only fast, for us quality is number one.</p>
@@ -235,7 +235,7 @@
         <section id="reviews">
             <div class="wrapper p-top flex gap-3" data-aos="fade-up">
                 <div class="image-container" data-aos="fade-right">
-                    <img src="../imgs/delivery-boy-with-phone.webp" alt="Delivery boy checking orders on a smartphone">
+                    <img src="../imgs/delivery-boy-with-phone.webp" alt="Delivery boy checking orders on a smartphone" loading="lazy">
                 </div>
                 <div class="review-container" data-aos="fade-left">
                     <h5 data-i18n="reviews.sectionTitle">Our reviews</h5>
@@ -245,7 +245,7 @@
                             <div class="swiper-slide">
                                 <div class="flex gap-3 mt-4">
                                     <div class="profile">
-                                        <img src="../imgs/profile1.webp" alt="Deepak Kumar">
+                                        <img src="../imgs/profile1.webp" alt="Deepak Kumar" loading="lazy">
                                     </div>
                                     <div class="">
                                         <h4 data-i18n="reviews.deepakName"></h4>
@@ -265,7 +265,7 @@
                             <div class="swiper-slide">
                                 <div class="flex gap-3 mt-4">
                                     <div class="profile">
-                                        <img src="../imgs/profile2.webp" alt="Priya Roy">
+                                        <img src="../imgs/profile2.webp" alt="Priya Roy" loading="lazy">
                                     </div>
                                     <div class="">
                                         <h4 data-i18n="reviews.priyaName"></h4>
@@ -284,7 +284,7 @@
                             <div class="swiper-slide">
                                 <div class="flex gap-3 mt-4">
                                     <div class="profile">
-                                        <img src="../imgs/profile3.webp" alt="Anjali Joshi">
+                                        <img src="../imgs/profile3.webp" alt="Anjali Joshi" loading="lazy">
                                     </div>
                                     <div class="">
                                         <h4 data-i18n="reviews.anjaliName"></h4>
@@ -313,7 +313,7 @@
             <div class="wrapper">
                 <div class="app-container flex gap-3">
                     <div class="app-image" data-aos="fade-right">
-                        <img src="../imgs/mobile-app.webp" alt="Food delivery mobile app interface">
+                        <img src="../imgs/mobile-app.webp" alt="Food delivery mobile app interface" loading="lazy">
                     </div>
 
                     <div class="content app-download-content" data-aos="fade-left">


### PR DESCRIPTION
# Pull Request Title

perf: Improve LCP by adding lazy loading to images

# Description

## Overview

This PR improves the Core Web Vitals (specifically Largest Contentful Paint) of the application by implementing native lazy loading for images.

## Changes Made

* Added `loading="lazy"` attribute to below-the-fold images in `index.html`
* Optimized image rendering performance
* Reduced initial page load payload
* Improved time-to-interactive for end users

## Issue Linked

Closes # (Add issue number if applicable)

## Type of Change

* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change
* [x] UI/UX improvement (Performance)
* [ ] Documentation update

## Screenshots / Demo

### Before

N/A (Performance improvement, no visual UI change)

### After

N/A (Performance improvement, no visual UI change)

## Testing

Tested on:

* Chrome
* Edge
* Mobile viewport
* Tablet viewport

## Checklist

* [x] Code follows project guidelines
* [x] Properly tested changes
* [x] No new warnings/errors
* [ ] Documentation updated if required
* [ ] Issue properly linked

## Additional Notes

By deferring the loading of off-screen images, users on slower networks or mobile devices will experience a much faster initial page load.
