### PR TITLE
fix: center hamburger/cross icon in navbar on small screens (≤667px)

### DIFF
--- a/css/modern-design.css
+++ b/css/modern-design.css
@@ -483,7 +483,7 @@ footer {
     p { font-size: 1rem !important; }
     
     .desktop-action { display: none !important; } /* Hide desktop actions on mobile */
-    .hamberger { display: block !important; }
+    .hamberger { display: flex !important; }
     
     .hero-section { text-align: center !important; }
     .hero-section .content { padding: 0 !important; }

--- a/css/style.css
+++ b/css/style.css
@@ -270,7 +270,7 @@
             display: none !important;
         }
         .desktop-action .hamberger {
-            display: block !important;
+            display: flex !important;
         }
     }
 
@@ -510,6 +510,10 @@
         font-size: 1.5rem;
         display: none;
         cursor: pointer;
+        align-items: center;
+        justify-content: center;
+        width: 2rem;
+        height: 2rem;
     }
 
     .desktop-action .hamberger i {
@@ -1153,7 +1157,7 @@
         }
 
         .desktop-action .hamberger {
-            display: block;
+            display: flex;
         }
 
         .desktop-action {


### PR DESCRIPTION
## Summary
- Fixed cross icon (✖) misalignment when toggling hamburger menu on small screens (≤667px)
- Added flexbox centering (\lign-items\, \justify-content\) and explicit \width\/\height\ to the \.hamberger\ anchor tag
- Updated all media query overrides from \display: block\ to \display: flex\ so flex centering properties take effect