### PR TITLE
Fix: Add safe fallbacks for `FoodieErrorHandler` destructuring

### DIFF
--- a/js/contributors.js
+++ b/js/contributors.js
@@ -70,12 +70,11 @@ async function initData() {
 
     // Import error handling utilities
     const {
-        retry,
-        NetworkError,
-        showErrorToast,
-        errorLogger
+        retry = async (fn) => fn(),
+        NetworkError = Error,
+        showErrorToast = console.error,
+        errorLogger = { log: console.error }
     } = window.FoodieErrorHandler || {};
-
     try {
         // Show loading
         setLoadingState(document.body, true, 'Loading contributors...');

--- a/js/contributors.js
+++ b/js/contributors.js
@@ -438,9 +438,9 @@ async function fetchRecentActivity() {
 
     // Import error handling utilities
     const {
-        retry,
-        NetworkError,
-        errorLogger
+        retry = async (fn) => fn(),
+        NetworkError = Error,
+        errorLogger = { log: console.error }
     } = window.FoodieErrorHandler || {};
 
     try {

--- a/js/contributors.js
+++ b/js/contributors.js
@@ -140,9 +140,9 @@ async function fetchAllPulls() {
 
     // Import error handling utilities
     const {
-        retry,
-        NetworkError,
-        errorLogger
+        retry = async (fn) => fn(),
+        NetworkError = Error,
+        errorLogger = { log: console.error }
     } = window.FoodieErrorHandler || {};
 
     // Fetching top 300 recent PRs. Increase page limit if needed, but be wary of API limits.


### PR DESCRIPTION
### Description

This PR adds default values when destructuring `window.FoodieErrorHandler` in 
`initData`, `fetchAllPulls`, and `fetchRecentActivity`. Previously, if 
`FoodieErrorHandler` was `undefined` at runtime, all destructured values (`retry`, 
`errorLogger`, etc.) became `undefined`, causing a `TypeError` on first use — 
**before** the surrounding `try/catch` could handle it, silently breaking the 
contributors page.

Closes #663 

---

### Changes

- Added inline default values for `retry`, `NetworkError`, `showErrorToast`, and 
  `errorLogger` in all three destructuring blocks
- No new files or test infrastructure added — fix is scoped to existing destructuring 
  patterns in `contributors.js`

---

### Before

```js
const {
    retry,
    NetworkError,
    showErrorToast,
    errorLogger
} = window.FoodieErrorHandler || {};
```

### After

```js
const {
    retry = async (fn) => fn(),
    NetworkError = Error,
    showErrorToast = console.error,
    errorLogger = { log: console.error }
} = window.FoodieErrorHandler || {};
```

*(`fetchAllPulls` and `fetchRecentActivity` use the same pattern minus `showErrorToast`.)*

---

### Commits

- `fix: add safe fallbacks for FoodieErrorHandler destructuring in initData`
- `fix: add safe fallbacks for FoodieErrorHandler destructuring in fetchAllPulls`
- `fix: add safe fallbacks for FoodieErrorHandler destructuring in fetchRecentActivity`