### PR TITLE
fix: align guest cart storage key/field in menu.js with checkout.js

### DIFF
--- a/js/menu.js
+++ b/js/menu.js
@@ -76,17 +76,27 @@ function toggleFav(id, card) {
   if (currentFilters.favOnly) renderCards(getFilteredProducts());
 }
 
+function showAddToCartToast(message) {
+  if (typeof showToast === 'function') { showToast(message); return; }
+  const container = document.querySelector('.toast-container') || document.body;
+  const toast = document.createElement('div');
+  toast.className = 'toast show';
+  toast.textContent = message;
+  container.appendChild(toast);
+  setTimeout(() => toast.remove(), 2500);
+}
+
 window.addToCart = function(id) {
   const product = allProducts.find(p => p.id === id);
   if (!product) return;
-  let cart = JSON.parse(localStorage.getItem('cart') || '[]');
+  let cart = JSON.parse(localStorage.getItem('foodie:cart') || '[]');
   const existing = cart.find(i => i.id === id);
-  if (existing) existing.qty += 1;
-  else cart.push({ ...product, qty: 1 });
-  localStorage.setItem('cart', JSON.stringify(cart));
+  if (existing) existing.quantity += 1;
+  else cart.push({ ...product, quantity: 1 });
+  localStorage.setItem('foodie:cart', JSON.stringify(cart));
   const cartValue = document.querySelector('.cart-value');
-  if (cartValue) cartValue.textContent = cart.reduce((a, i) => a + i.qty, 0);
-  alert(`${product.name} added to cart!`);
+  if (cartValue) cartValue.textContent = cart.reduce((a, i) => a + i.quantity, 0);
+  showAddToCartToast(`${product.name} added to cart!`);
 };
 
 function bindDropdown(selectorId, filterKey) {


### PR DESCRIPTION
## 📝 Description
This issue describes guest users being unable to add items to cart without logging in. After tracing the actual cart flow, I found there's no login check anywhere blocking add-to-cart — the real problem is a data bug that produces the same symptom: items added from menu.html were saved to a different localStorage key (cart, field qty) than the one checkout.js reads (foodie:cart, field quantity). So clicking "Add to Cart" appeared to work (toast/count updated) but the item never reached checkout, making the cart look broken for everyone, not just guests.

## 🔗 Related Issue
Closes #533 

## 🛠 Changes
- `addToCart` now reads/writes `localStorage['foodie:cart']` instead of `localStorage['cart']`
- Cart items now use quantity instead of qty to match `checkout.js` expectations
- Replaced the blocking alert() with a toast using the existing `.toast-container` and `css/toast.css` already loaded on `menu.html`
- 
## ✅ Checklist
- [x] My code follows the project guidelines.
- [x] I have tested the changes.
- [ ] Documentation updated if needed.
- [x] PR title is descriptive.

## 📷 Screenshots (optional)
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/855b5e8a-6360-45ce-969e-030837d7e49a" />

<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/48519cca-c911-450b-a268-08aa672cdb5d" />

