### PR TITLE
fix: restore visible focus states and add missing labels

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -199,6 +199,18 @@ main {
         margin: auto;
     }
 
+    .sr-only {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+    }
+
     /* HEADER STYLING - UPDATED FOR TRANSPARENT NAVBAR */
 
     header {
@@ -215,6 +227,16 @@ main {
     header.scrolled {
         background-color: var(--bg-secondary);
         box-shadow: 0 2px 5px var(--shadow);
+    }
+
+     a:focus-visible,
+    button:focus-visible,
+    input:focus-visible,
+    textarea:focus-visible,
+    select:focus-visible,
+    [tabindex]:focus-visible {
+        outline: 2px solid var(--gold-finger) !important;
+        outline-offset: 2px !important;
     }
 
     /* Override wrapper constraints inside header */

--- a/html/index.html
+++ b/html/index.html
@@ -108,7 +108,7 @@
             </a>
 
             <!-- Hamburger -->
-            <a href="#" class="hamberger"><i class="fa-solid fa-bars"></i></a>
+            <a href="#" class="hamberger" aria-label="Open menu"><i class="fa-solid fa-bars" aria-hidden="true"></i></a>
         </div>
 
         <!-- MOBILE MENU -->
@@ -318,8 +318,12 @@
                             </div>
                         </div>
                         <div class="flex between mt-4">
-                            <a href="#" class="arrow"><i class="fa-solid fa-arrow-left"></i></a>
-                            <a href="#" class="arrow"><i class="fa-solid fa-arrow-right"></i></a>
+                            <a href="#" class="arrow" aria-label="Previous review">
+                                <i class="fa-solid fa-arrow-left" aria-hidden="true"></i>
+                            </a>
+                            <a href="#" class="arrow" aria-label="Next review">
+                                <i class="fa-solid fa-arrow-right" aria-hidden="true"></i>
+                            </a>
                         </div>
                     </div>
                 </div>
@@ -433,6 +437,7 @@
                         drop you email below to get daily update about us.</p>
 
                     <form id="newsletterForm" class="input-container flex" data-aos="fade-up" data-aos-delay="200">
+                        <label for="email" class="sr-only">Email address</label>
                         <input type="email" id="email" placeholder="Enter your email"
                             data-i18n-placeholder="newsletter.placeholder" />
 


### PR DESCRIPTION
## 📝 Description
Several CSS files set outline: none on focus with no replacement, making keyboard navigation invisible. index.html also had a hamburger button and two carousel arrows with no aria-label, and a newsletter email input with only a placeholder and no <label>.
## 🔗 Related Issue
Closes #660 

## 🛠 Changes
- Fixed all three with a global :focus-visible rule (benefits every page automatically, since style.css is shared site-wide) plus targeted aria-label/<label> additions on index.html.
- Tested with keyboard-only navigation and a screen reader (see commit message for full checklist).

## ✅ Checklist
- [x] My code follows the project guidelines.
- [x] I have tested the changes.
- [ ] Documentation updated if needed.
- [x] PR title is descriptive.

## 📷 Screenshots (optional)
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/6b56690b-6545-4f3b-9e0d-58911c08548e" />

