### PR TITLE
fix: close Marker constructor in nearby restaurantsfix: close Marker constructor in nearby restaurants

### DIFF
--- a/js/nearby-restaurants-home.js
+++ b/js/nearby-restaurants-home.js
@@ -193,6 +193,7 @@
             map,
             position: place.geometry.location,
             title: place.name || t('nearby.restaurant', 'Restaurant'),
+        });
         marker.addListener('click', () => {
             const rating = typeof place.rating === 'number' ? place.rating.toFixed(1) : 'N/A';
             const address = place.vicinity || place.formatted_address || 'Address unavailable';


### PR DESCRIPTION
## Summary

Fixes a syntax error in `js/nearby-restaurants-home.js`.

The `google.maps.Marker(...)` constructor inside `addRestaurantMarker()` was missing its closing `});`, causing the JavaScript parser to fail with:

SyntaxError: Unexpected token '.'

As a result, the Nearby Restaurants section could not execute.

## Fix

- Added the missing closing `});` before `marker.addListener()`.

## Verification

- `node -c js/nearby-restaurants-home.js` passes successfully.
- Only one file was modified.
- No functional changes besides fixing the syntax error.