### PR TITLE
generalizing `scripts/check_json.py` to automatically scan and validate all translation JSON files

### DIFF
--- a/scripts/check_json.py
+++ b/scripts/check_json.py
@@ -1,12 +1,39 @@
+import sys
 import json
 from pathlib import Path
-path = Path('locales/mr.json')
-text = path.read_text(encoding='utf-8')
-try:
-    json.loads(text)
-    print('OK')
-except json.JSONDecodeError as e:
-    print('ERROR', e)
-    start = max(0, e.pos - 60)
-    end = min(len(text), e.pos + 60)
-    print(text[start:end])
+
+def main():
+    locales_dir = Path('locales')
+    
+    if not locales_dir.exists():
+        print(f"ERROR: Locales directory not found at {locales_dir}")
+        sys.exit(1)
+
+    json_files = sorted(list(locales_dir.glob('*.json')))
+    
+    if not json_files:
+        print(f"WARNING: No JSON locale files found in {locales_dir}")
+        sys.exit(0)
+
+    success = True
+    
+    for file_path in json_files:
+        try:
+            text = file_path.read_text(encoding='utf-8')
+            json.loads(text)
+            print(f"SUCCESS: Validated {file_path}")
+        except json.JSONDecodeError as e:
+            print(f"ERROR: Malformed JSON in {file_path} -> {e}")
+            start = max(0, e.pos - 60)
+            end = min(len(text), e.pos + 60)
+            print(f"Context:\n{text[start:end]}")
+            success = False
+        except Exception as e:
+            print(f"ERROR: Could not read {file_path} -> {e}")
+            success = False
+
+    if not success:
+        sys.exit(1)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION


## Description
This PR resolves Issue #710 by generalizing `scripts/check_json.py` to automatically scan and validate all translation JSON files inside the `locales/` directory rather than hardcoding a single file path.

### Changes Made:
- **Dynamic File Discovery:** Added directory scanning via `Path('locales').glob('*.json')` to capture all regional translation files.
- **Detailed Reporting:** Printed explicit success or diagnostic failure context for each checked locale file.
- **Robust Pipeline Blocking:** Configured the script to track overall validation success and exit with code `1` (`sys.exit(1)`) if any JSON parsing error occurs, ensuring faulty builds are successfully blocked in CI/CD.

### Acceptance Criteria Checklist:
- [x] Update `check_json.py` to scan and load all JSON files in `locales/`.
- [x] Print clear success/error reports for every checked locale file.
- [x] Ensure script exits with code `1` if any JSON decoding error is detected.

