### PR TITLE
Verified that clicking the retry button successfully triggers a re-fetch

### DIFF
--- a/js/contributors.js
+++ b/js/contributors.js
@@ -122,7 +122,7 @@ async function initData() {
                     <div class="error-icon">⚠️</div>
                     <h3>${t('contributors.failedTitle', 'Failed to Load Contributors')}</h3>
                     <p>${t('contributors.failedMessage', 'Unable to load contributor data. This might be due to API rate limits or network issues.')}</p>
-                    <button class="retry-btn" onclick="initializeData()">${t('contributors.retry', 'Retry')}</button>
+                    <button class="retry-btn" onclick="initData()">${t('contributors.retry', 'Retry')}</button>
                 </div>
             `;
         }


### PR DESCRIPTION
## Description
This PR resolves [Issue #719](https://github.com/janavipandole/Foodie/issues/719) by correcting an undefined function reference (`initializeData`) in the error state retry handler within `js/contributors.js`, updating it to properly invoke `initData()`.

### Changes Made:
- **Error State Fix:** Replaced `onclick="initializeData()"` with `onclick="initData()"` in the network error rendering block.
- **Retry Functionality:** Verified that clicking the retry button successfully triggers a re-fetch of contributor data upon network failure without throwing a `ReferenceError`.

### Acceptance Criteria Checklist:
- [x] Replace `onclick="initializeData()"` with `onclick="initData()"` in `js/contributors.js`.
- [x] Verify that clicking the retry button correctly triggers a re-fetch of contributor data.

