### PR TITLE
`js/favorites.js`, removing the top-level IIFE wrapper, and exposing clean ES module exports

### DIFF
--- a/js/favorites.js
+++ b/js/favorites.js
@@ -1,24 +1,53 @@
-(function() {
+/**
+ * Favorites Module
+ * Manages favorite items persistence, filtering, and DOM rendering.
+ */
+
 let allProducts = [];
 let currentTypeFilter = 'all';
 
-function getFavoriteIds() {
-  return JSON.parse(localStorage.getItem('favorites') || '[]');
+/**
+ * Retrieves the list of favorite item IDs from localStorage.
+ * @returns {Array<string|number>} Array of favorite IDs
+ */
+export function getFavoriteIds() {
+  try {
+    const stored = localStorage.getItem('favorites');
+    return stored ? JSON.parse(stored) : [];
+  } catch (error) {
+    console.error('Failed to parse favorites from localStorage:', error);
+    return [];
+  }
 }
 
-function getFavoriteProducts() {
+/**
+ * Retrieves full favorite product objects based on stored IDs.
+ * @param {Array} productsCatalog - Full catalog of products
+ * @returns {Array} Array of favorite product objects
+ */
+export function getFavoriteProducts(productsCatalog = allProducts) {
   const favs = getFavoriteIds();
-  return allProducts.filter(p => favs.includes(p.id));
+  return productsCatalog.filter(p => favs.includes(p.id));
 }
 
-function getFilteredFavorites() {
-  return getFavoriteProducts().filter(p => {
-    if (currentTypeFilter !== 'all' && p.type !== currentTypeFilter) return false;
+/**
+ * Filters favorite products based on the current type filter ('all', 'veg', 'non-veg').
+ * @param {Array} products - Array of favorite products
+ * @param {string} filterType - Filter category
+ * @returns {Array} Filtered products array
+ */
+export function getFilteredFavorites(products = getFavoriteProducts(), filterType = currentTypeFilter) {
+  currentTypeFilter = filterType;
+  return products.filter(p => {
+    if (filterType !== 'all' && p.type !== filterType) return false;
     return true;
   });
 }
 
-async function loadFavorites() {
+/**
+ * Loads favorites data from products.json and renders the cards.
+ */
+export async function loadFavorites() {
   const container = document.getElementById('itemsNotAvailable');
   if (!container) return;
   try {
@@ -30,13 +59,20 @@ async function loadFavorites() {
   }
 }
 
-function renderCards(products) {
+/**
+ * Renders favorite product cards onto the DOM.
+ * @param {Array} products - Products to render
+ */
+export function renderCards(products) {
   const container = document.getElementById('itemsNotAvailable');
+  if (!container) return;
   container.innerHTML = '';
+  
   if (products.length === 0) {
     container.innerHTML = '<p style="text-align:center;width:100%;padding:40px;">No favorites yet. Tap the heart icon on any item in the menu to save it here.</p>';
     return;
   }
+  
   products.forEach(p => {
     const card = document.createElement('div');
     card.className = 'order-card';
@@ -49,22 +85,38 @@ function renderCards(products) {
       <p style="color:#888;font-size:13px;">${p.cuisine} • ${p.type}</p>
       <p style="font-size:13px;">⭐ ${p.rating}</p>
       <p style="font-weight:bold;">₹${p.price}</p>
-      <button onclick="addFavoriteToCart(${p.id})" style="margin-top:8px;width:100%;padding:8px;background:#ff6b6b;color:#fff;border:none;border-radius:6px;cursor:pointer;">Add to Cart</button>
+      <button class="add-to-cart-btn" data-id="${p.id}" style="margin-top:8px;width:100%;padding:8px;background:#ff6b6b;color:#fff;border:none;border-radius:6px;cursor:pointer;">Add to Cart</button>
     `;
+    
     card.querySelector('.fav-icon').addEventListener('click', () => removeFavorite(p.id));
+    card.querySelector('.add-to-cart-btn').addEventListener('click', () => addFavoriteToCart(p.id));
+    
     container.appendChild(card);
   });
 }
 
-function removeFavorite(id) {
+/**
+ * Removes a product from favorites in localStorage and re-renders cards.
+ * @param {string|number} id - Product ID
+ * @returns {Array} Updated favorite IDs
+ */
+export function removeFavorite(id) {
   let favs = getFavoriteIds();
   favs = favs.filter(f => f !== id);
   localStorage.setItem('favorites', JSON.stringify(favs));
   renderCards(getFilteredFavorites());
+  return favs;
 }
 
-function showFavoriteToast(message) {
-  if (typeof showToast === 'function') { showToast(message); return; }
+/**
+ * Shows a toast message notification.
+ * @param {string} message - Toast text
+ */
+export function showFavoriteToast(message) {
+  if (typeof showToast === 'function') { 
+    showToast(message); 
+    return; 
+  }
   const container = document.querySelector('.toast-container') || document.body;
   const toast = document.createElement('div');
   toast.className = 'toast show';
@@ -73,7 +125,11 @@ function showFavoriteToast(message) {
   setTimeout(() => toast.remove(), 2500);
 }
 
-window.addFavoriteToCart = function(id) {
+/**
+ * Adds a favorite item directly to the cart.
+ * @param {string|number} id - Product ID
+ */
+export function addFavoriteToCart(id) {
   const product = allProducts.find(p => p.id === id);
   if (!product) return;
   let cart = JSON.parse(localStorage.getItem('foodie:cart') || '[]');
@@ -81,29 +137,48 @@ window.addFavoriteToCart = function(id) {
   if (existing) existing.quantity += 1;
   else cart.push({ ...product, quantity: 1 });
   localStorage.setItem('foodie:cart', JSON.stringify(cart));
+  
   const cartValue = document.querySelector('.cart-value');
   if (cartValue) cartValue.textContent = cart.reduce((a, i) => a + i.quantity, 0);
   showFavoriteToast(`${product.name} added to cart!`);
-};
+}
 
-document.addEventListener('DOMContentLoaded', () => {
-  loadFavorites();
+// ===== DOM INITIALIZATION =====
+if (typeof document !== 'undefined') {
+  document.addEventListener('DOMContentLoaded', () => {
+    loadFavorites();
 
-  const vegBtn = document.getElementById('filterVeg');
-  const nonVegBtn = document.getElementById('filterNonVeg');
-  const allBtn = document.getElementById('filterAll');
+    const vegBtn = document.getElementById('filterVeg');
+    const nonVegBtn = document.getElementById('filterNonVeg');
+    const allBtn = document.getElementById('filterAll');
 
-  vegBtn && vegBtn.addEventListener('click', () => {
-    currentTypeFilter = 'veg';
-    renderCards(getFilteredFavorites());
+    vegBtn && vegBtn.addEventListener('click', () => {
+      currentTypeFilter = 'veg';
+      renderCards(getFilteredFavorites());
+    });
+    
+    nonVegBtn && nonVegBtn.addEventListener('click', () => {
+      currentTypeFilter = 'non-veg';
+      renderCards(getFilteredFavorites());
+    });
+    
+    allBtn && allBtn.addEventListener('click', () => {
+      currentTypeFilter = 'all';
+      renderCards(getFilteredFavorites());
+    });
   });
-  nonVegBtn && nonVegBtn.addEventListener('click', () => {
-    currentTypeFilter = 'non-veg';
-    renderCards(getFilteredFavorites());
-  });
-  allBtn && allBtn.addEventListener('click', () => {
-    currentTypeFilter = 'all';
-    renderCards(getFilteredFavorites());
-  });
-});
-})();
+}
+
+// Global window bindings for backward compatibility
+if (typeof window !== 'undefined') {
+  window.addFavoriteToCart = addFavoriteToCart;
+  window.favoritesModule = {
+    getFavoriteIds,
+    getFavoriteProducts,
+    getFilteredFavorites,
+    loadFavorites,
+    renderCards,
+    removeFavorite,
+    addFavoriteToCart
+  };
+}


### PR DESCRIPTION


## Description
This PR resolves [Issue #722](https://github.com/janavipandole/Foodie/issues/722) by modularizing `js/favorites.js`, removing the top-level IIFE wrapper, and exposing clean ES module exports for core favorite management helpers (`getFavoriteIds`, `getFavoriteProducts`, `getFilteredFavorites`, `removeFavorite`, `loadFavorites`).

### Changes Made:
- **ES Module Exports:** Exported core helper functions directly from `favorites.js` to enable automated Jest unit test suites.
- **State & Storage Management:** Refactored local storage retrieval, filtering (`all`, `veg`, `non-veg`), card rendering, and item removal logic.
- **Backward Compatibility:** Preserved DOM event listener bindings and global window helper attachments for runtime browser execution.

### Acceptance Criteria Checklist:
- [x] Export `getFavoriteIds`, `getFavoriteProducts`, `getFilteredFavorites`, `loadFavorites`, and `removeFavorite` from `favorites.js`.
- [x] Ensure DOM initialization and filter event listeners operate smoothly without errors.
- [x] Verify favorite items persist correctly and update `localStorage` as expected.

