### PR TITLE
refactor(popular): modularize AOS initialization and export ES module exports in [popular.js]

### DIFF
--- a/js/popular.js
+++ b/js/popular.js
@@ -1,8 +1,44 @@
-document.addEventListener('DOMContentLoaded', () => {
-    AOS.init({
-        duration: 800,
-        easing: 'ease-out',
-        once: true,
-        offset: 100
+/**
+ * Popular Page Module
+ * Handles AOS (Animate On Scroll) library initialization and configuration.
+ */
+
+/**
+ * Initializes AOS animations with preset options.
+ * @returns {Object|null} Initialized AOS instance or null if AOS is unavailable
+ */
+export function initAOS() {
+    if (typeof window !== 'undefined' && typeof AOS !== 'undefined' && typeof AOS.init === 'function') {
+        return AOS.init({
+            duration: 800,
+            easing: 'ease-out',
+            once: true,
+            offset: 100
+        });
+    }
+    return null;
+}
+
+/**
+ * Initializes popular page features and animations.
+ */
+export function initPopularPage() {
+    return initAOS();
+}
+
+// ===== DOM INITIALIZATION =====
+if (typeof document !== 'undefined') {
+    document.addEventListener('DOMContentLoaded', () => {
+        initPopularPage();
     });
-});
+}
+
+// Global window bindings for legacy script execution
+if (typeof window !== 'undefined') {
+    window.initAOS = initAOS;
+    window.initPopularPage = initPopularPage;
+    window.popularModule = {
+        initAOS,
+        initPopularPage
+    };
+}


### PR DESCRIPTION
## Description
This PR resolves [Issue #737](https://github.com/janavipandole/Foodie/issues/737) by modularizing [`popular.js`](https://github.com/janavipandole/Foodie/blob/main/js/popular.js), removing the anonymous top-level DOM listener constraint, and explicitly exporting an initialization function (`initPopularPage` / `initAOS`) to support automated Jest unit test suites.

### Changes Made:
- **ES Module Export:** Exported `initPopularPage` (and `initAOS`) directly from [`popular.js`](https://github.com/janavipandole/Foodie/blob/main/js/popular.js).
- **Environment Safety:** Added guards around `document` and `window` references (as well as checking for `typeof AOS !== 'undefined'`) to ensure server-side rendering and test suites execute smoothly without errors.
- **Backward Compatibility:** Maintained automated DOM initialization (`DOMContentLoaded`) and global window bindings (`window.popularModule`, `window.initPopularPage`) for legacy script execution.

### Acceptance Criteria Checklist:
- [x] Export initialization functions from `js/popular.js`.
- [x] Ensure AOS animations initialize smoothly with correct options (`duration: 800`, `easing: 'ease-out'`, `once: true`, `offset: 100`).
- [x] Verify that page initialization runs without errors upon DOM content loading.

